### PR TITLE
Some bug and typo fixes

### DIFF
--- a/alias-reversing/apps/find-alias-individual/README.md
+++ b/alias-reversing/apps/find-alias-individual/README.md
@@ -1,9 +1,9 @@
-#Find Aliases Individual Tool
+# Find Aliases Individual Tool
 
 ## Background
-For this section we assume that you a DIMM that reports twice the actual size due to SPD data manipulation. Depending on the exact aliasing function, the system might run very unstable or even crash during boot. To improve system stability we use the `memmap` Linux kernel paramter to prevent the system from using the whole upper half of the physical memory range. Assuming a 32 GiB DIMM that has been manipulated to report 64 GiB, we start the Linux kernel with `memmap=0x800000000$0x800000000`. (If you enter this on the GRUB command line during boot, you need to escape the `$` with `\$`. If you want to change this via the `GRUB_CMDLINE_LINUX` variable in the `/etc/default/grub` config file, you need to use `\\\$` to also escape the slash itself)
+For this section we assume that you have a DIMM that reports twice the actual size due to SPD data manipulation. Depending on the exact aliasing function, the system might run very unstable or even crash during boot. To improve system stability we use the `memmap` Linux kernel parameter to prevent the system from using the whole upper half of the physical memory range. Assuming a 32 GiB DIMM that has been manipulated to report 64 GiB, we start the Linux kernel with `memmap=0x800000000$0x800000000`. (If you enter this on the GRUB command line during boot, you need to escape the `$` with `\$`. If you want to change this via the `GRUB_CMDLINE_LINUX` variable in the `/etc/default/grub` config file, you need to use `\\\$` to also escape the slash itself)
 
-To recover the aliased address *ALIAS(A)* for a phyiscal address *A* we peform the following experiment
+To recover the aliased address *ALIAS(A)* for a phyiscal address *A* we perform the following experiment
 1) Loop over the whole physical address space. Let *B* be the currently tested candidate
 2) Write a random marker value *m1* to *A*
 3) Read from *B* and store the result in *bm1*
@@ -12,15 +12,15 @@ To recover the aliased address *ALIAS(A)* for a phyiscal address *A* we peform t
 6) Check if `m1 xor m2` equals `bm1 xor bm2`. If true, *B* is the alias for *A*.
 
 The reasons for the two-step xor comparison instead of simply checking if *B* contains *m1*
-is that many systems use memory scrambling, where the memory controller xors a physical address depdendent value to payload data before sending it to the DIMM. When accessing address *A* through its alias *ALIAS(A)* the memory controller will xor a different scrambling value due to the differences in the physical address. However, since the scrambling value is xored to the data, the xor
+is that many systems use memory scrambling, where the memory controller xors a physical address dependent value to the payload data before sending it to the DIMM. When accessing address *A* through its alias *ALIAS(A)* the memory controller will xor a different scrambling value due to the differences in the physical address. However, since the scrambling value is xored to the data, the xor
 of *m1* and *m2* will still be equal to the xor of *bm1* and *bm2*.
 
 ## Tool Design
-During our experiments, we found that on some systems the physical address space is not contiguous but fractured. Furthermore different ranges of the address space seem to require different shifts/alias functions. The `fai` tools first parses `/proc/iomem` to get a list of all physical memory ranges known to the sytem. Next, it filters all memory ranges that do not corespond to the main memory. Afterwards it performs the experiment from the previous section for one address of each remaining memory range. The outputs are stored in `aliases.csv`. Depending on the RAM size, the tool might require a bit of time. We recommend to run it with e.g. `tmux`.
+During our experiments, we found that on some systems the physical address space is not contiguous but fractured. Furthermore different ranges of the address space seem to require different shifts/alias functions. The `fai` tools first parses `/proc/iomem` to get a list of all physical memory ranges known to the sytem. Next, it filters all memory ranges that do not correspond to the main memory. Afterwards it performs the experiment from the previous section for one address of each remaining memory range. The outputs are stored in `aliases.csv`. Depending on the RAM size, the tool might require a bit of time. We recommend to run it with e.g. `tmux`.
 
 ## Build
 
-1) If you don't build on the target system, you will need to to point the build system to the Linux kernel headers of the target system by setting `export KERNEL_PATH <path to headers>`
+1) If you don't build on the target system, you will need to point the build system to the Linux kernel headers of the target system by setting `export KERNEL_PATH <path to headers>`
 2) `make`
 
 This will produces the following artifacts:
@@ -53,7 +53,7 @@ Mem Range{.start=0x0aa3ff000, .end=0x0abffffff} : orig=0x0aa400000 alias=0x8fa43
 Mem Range{.start=0x100000000, .end=0x7ffffffff} : orig=0x100001000 alias=0x900031000 xor=0x800030000
 Mem Range{.start=0x1000000000, .end=0x104f0fffff} : orig=0x1000001000 alias=0x800031000 xor=0x1800030000  
 ```
-Each line corresponds to one memory range witht the given start and end address. The address `orig` is the address for which the searched the alias and `alias` is the found alias address. `xor` is the alias shift/mask obtained by xoring `orig` and `alias`. It is assumed that the alias is the same for all addresses from the same memory range.
+Each line corresponds to one memory range with the given start and end address. The address `orig` is the address for which the tool searched the alias and `alias` is the found alias address. `xor` is the alias shift/mask obtained by xoring `orig` and `alias`. It is assumed that the alias is the same for all addresses from the same memory range.
 
 ### Reversing RMP alias
 
@@ -63,7 +63,7 @@ parts of the memory range, breaking one of the basic assumptions of the fai tool
 
 To cope with this situation, use the `--input` param of the tools, to feed it a list of physical addresses for which it should search an alias.
 Choose these addresses such that they are distributed over the RMP memory range.
-In addition, you need to use the `--access-reserved` option
+In addition, you need to use the `--access-reserved` option.
 
 You need to disabled SEV-SNP in the BIOS before reverse engineering. Otherwise, we cannot write to the RMP memory range. On our system, the RMP was always
 at the same physical addresses.

--- a/alias-reversing/apps/find-alias-individual/find_alias_individual.c
+++ b/alias-reversing/apps/find-alias-individual/find_alias_individual.c
@@ -890,7 +890,7 @@ int mode_find(struct cli_flags flags) {
     }
 
     //Search alias for each source_pa
-    uint64_t* alias_pa = calloc(sizeof(uint64_t), source_candidates_len);
+    uint64_t* alias_pa = calloc(source_candidates_len, sizeof(uint64_t));
     for( size_t i = 0; i < source_candidates_len; i++) {
         printf("[%ju/%ju[: Searching alias for 0x%jx\n", i, source_candidates_len, source_candidates[i].pa);
         //First check if any of the already found alias shifts work

--- a/alias-reversing/modules/read_alias/kmod_readalias.c
+++ b/alias-reversing/modules/read_alias/kmod_readalias.c
@@ -4,6 +4,7 @@
 #include <linux/module.h>
 #include <linux/version.h>
 #include <linux/io.h>
+#include <linux/vmalloc.h>
 
 #include "include/readalias_ioctls.h"
 

--- a/alias-reversing/modules/read_alias/readme.md
+++ b/alias-reversing/modules/read_alias/readme.md
@@ -4,4 +4,4 @@ A kernel module that allows direct read/write access to physical memory. See `./
 
 See `common-code` for loading/storing and calculating aliased addresses.
 
-If you want to build the kernel module for a kernel different from the currently running one, set the `KERNEL_PATH` environment variable the the header files of the targeted kernel.
+If you want to build the kernel module for a kernel different from the currently running one, set the `KERNEL_PATH` environment variable to the header files of the targeted kernel.

--- a/sev-attacks/guest_context_replay/qemu-patches/base-version.txt
+++ b/sev-attacks/guest_context_replay/qemu-patches/base-version.txt
@@ -1,2 +1,2 @@
-Thes patches where applied against commit f246dd2ad51d2c6c3ce9a588a8ce9c6a2d8c20e1 of branch snp-latest of https://github.com/AMDESE/qemu.git
+These patches where applied against commit f246dd2ad51d2c6c3ce9a588a8ce9c6a2d8c20e1 of branch snp-latest of https://github.com/AMDESE/qemu.git
 


### PR DESCRIPTION
- Changes to make it compatible with gcc 14.2 and Linux 6.12.
- Created a '__clflush_range' function to reflect the design of '__memcpy_topa' to fix an uninitialized field bug.
- Fixed some small typos